### PR TITLE
generateSchema函数中的schemaStr默认为空

### DIFF
--- a/tool-nativeSchema.js
+++ b/tool-nativeSchema.js
@@ -97,7 +97,7 @@
         generateSchema: function(schema) {
 
             var localUrl  = window.location.href;
-            var schemaStr = "";
+            var schemaStr = schema;
 
             // 如果未定义schema，则根据当前路径来映射
             if (!schema) {


### PR DESCRIPTION
没用上传递进来schema，除安卓chrome浏览器以外其他结果只能输出:
```
AppConfig.PROTOCAL + "://";
```